### PR TITLE
Delay ticket form category initialization until after first frame

### DIFF
--- a/lib/features/ticket_form/presentation/views/ticket_form_page.dart
+++ b/lib/features/ticket_form/presentation/views/ticket_form_page.dart
@@ -71,7 +71,12 @@ class _TicketFormPageState extends ConsumerState<TicketFormPage> {
   @override
   void initState() {
     super.initState();
-    ref.read(ticketFormControllerProvider.notifier).setCategory(widget.initialCategory);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      ref
+          .read(ticketFormControllerProvider.notifier)
+          .setCategory(widget.initialCategory);
+    });
     _subscription = ref.listenManual<TicketFormState>(
       ticketFormControllerProvider,
       (TicketFormState? prev, TicketFormState next) {


### PR DESCRIPTION
## Summary
- delay ticket form category initialization to the first post-frame callback and guard against unmounted widgets

## Testing
- `dart format .` *(fails: command not found: dart)*
- `flutter test` *(fails: command not found: flutter)*
- `flutter build apk` *(fails: command not found: flutter)*
- `flutter build ipa` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68cda217d9008320943d640671b67bc2