### PR TITLE
Integrate Azure AD auth and Dataverse CRUD demo

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,15 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- Intent filter necesario para flutter_appauth. Ajusta scheme/host para que coincidan con AuthConfig.redirectUriAndroid -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="com.example.app"
+                    android:host="oauthredirect" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,7 +43,19 @@
 	</array>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <!-- Configuración de URL Schemes para flutter_appauth. Ajusta el scheme al de AuthConfig.redirectUriIos -->
+        <key>CFBundleURLTypes</key>
+        <array>
+                <dict>
+                        <key>CFBundleURLSchemes</key>
+                        <array>
+                                <string>com.example.app</string>
+                        </array>
+                        <key>CFBundleURLName</key>
+                        <string>auth</string>
+                </dict>
+        </array>
 </dict>
 </plist>

--- a/lib/config/auth_config.dart
+++ b/lib/config/auth_config.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/foundation.dart';
+
+/// Configuración estática para Azure AD y Dataverse.
+///
+/// Sustituye los valores con los de tu inquilino antes de compilar:
+/// - [tenantId]: ID del tenant Entra ID.
+/// - [clientId]: ID de la aplicación registrada.
+/// - [organizationHost]: URL base de Dataverse (termina con .crm.dynamics.com).
+/// - [redirectUriAndroid] y [redirectUriIos]: deben coincidir con los Redirect URIs
+///   configurados en el registro de la app.
+/// - [scopes]: incluye `.default` del recurso Dataverse y los scopes básicos.
+class AuthConfig {
+  const AuthConfig._();
+
+  static const String tenantId = '<TENANT_ID>';
+  static const String clientId = '<CLIENT_ID>';
+  static const String organizationHost = 'https://<ORG>.crm.dynamics.com';
+  static const String redirectUriAndroid = 'com.example.app:/oauthredirect';
+  static const String redirectUriIos = 'com.example.app:/oauthredirect';
+
+  /// Incluye `.default` para Dataverse y `offline_access` para refresh tokens.
+  static const List<String> scopes = <String>[
+    'openid',
+    'profile',
+    'offline_access',
+    'https://<ORG>.crm.dynamics.com/.default',
+  ];
+
+  static const String _authorizationEndpointTemplate =
+      'https://login.microsoftonline.com/<TENANT_ID>/oauth2/v2.0/authorize';
+  static const String _tokenEndpointTemplate =
+      'https://login.microsoftonline.com/<TENANT_ID>/oauth2/v2.0/token';
+
+  static String get authorizationEndpoint =>
+      _authorizationEndpointTemplate.replaceFirst('<TENANT_ID>', tenantId);
+
+  static String get tokenEndpoint =>
+      _tokenEndpointTemplate.replaceFirst('<TENANT_ID>', tenantId);
+
+  /// Devuelve el redirect URI correcto según la plataforma actual.
+  ///
+  /// Para Web se debe usar MSAL (msal-browser) o implementar un flujo PKCE
+  /// manual; `flutter_appauth` no soporta Web.
+  static String redirectUriForPlatform() {
+    if (kIsWeb) {
+      throw UnsupportedError(
+        'TODO: usar MSAL (msal-browser) o un flujo PKCE manual para Web.',
+      );
+    }
+
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return redirectUriAndroid;
+      case TargetPlatform.iOS:
+      case TargetPlatform.macOS:
+        return redirectUriIos;
+      case TargetPlatform.linux:
+      case TargetPlatform.windows:
+        // Ajusta este valor si registras URIs específicos para escritorio.
+        return redirectUriAndroid;
+      default:
+        return redirectUriAndroid;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,236 @@
-import 'package:sistema_tickets_edis/bootstrap.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'config/auth_config.dart';
+import 'pages/example_page.dart';
+import 'services/auth_service.dart';
+import 'services/dataverse_api.dart';
 
 Future<void> main() async {
-  await bootstrap();
+  WidgetsFlutterBinding.ensureInitialized();
+  final AuthService authService = AuthService();
+  final DataverseApi dataverseApi = DataverseApi(authService: authService);
+
+  runApp(
+    TicketDemoApp(
+      authService: authService,
+      dataverseApi: dataverseApi,
+    ),
+  );
+}
+
+class TicketDemoApp extends StatelessWidget {
+  const TicketDemoApp({
+    super.key,
+    required this.authService,
+    required this.dataverseApi,
+  });
+
+  final AuthService authService;
+  final DataverseApi dataverseApi;
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Azure AD + Dataverse',
+      debugShowCheckedModeBanner: false,
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+        useMaterial3: true,
+      ),
+      home: AuthGuard(
+        authService: authService,
+        dataverseApi: dataverseApi,
+      ),
+    );
+  }
+}
+
+class AuthGuard extends StatefulWidget {
+  const AuthGuard({
+    super.key,
+    required this.authService,
+    required this.dataverseApi,
+  });
+
+  final AuthService authService;
+  final DataverseApi dataverseApi;
+
+  @override
+  State<AuthGuard> createState() => _AuthGuardState();
+}
+
+class _AuthGuardState extends State<AuthGuard> {
+  bool _checkingSession = true;
+  bool _isAuthenticated = false;
+  bool _isProcessing = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _bootstrapSession();
+  }
+
+  Future<void> _bootstrapSession() async {
+    setState(() {
+      _checkingSession = true;
+    });
+    try {
+      final bool hasSession = await widget.authService.hasValidSession();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isAuthenticated = hasSession;
+      });
+      if (!hasSession) {
+        _showInfo(
+          'Configura AuthConfig con tu TENANT_ID, CLIENT_ID y Redirect URIs antes de iniciar sesión.',
+        );
+      }
+    } catch (error) {
+      _showError('No fue posible validar la sesión: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _checkingSession = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _login() async {
+    setState(() {
+      _isProcessing = true;
+    });
+    try {
+      await widget.authService.login();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _isAuthenticated = true;
+      });
+      _showInfo('Autenticación completada. Tokens almacenados en secure storage.');
+    } on AuthException catch (error) {
+      _showError(error.message);
+    } catch (error) {
+      _showError('Error inesperado al iniciar sesión: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessing = false;
+        });
+      }
+    }
+  }
+
+  void _handleLogout() {
+    setState(() {
+      _isAuthenticated = false;
+    });
+  }
+
+  void _showInfo(String message) {
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  void _showError(String message) {
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Theme.of(context).colorScheme.error,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_checkingSession) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
+    if (_isAuthenticated) {
+      return ExamplePage(
+        authService: widget.authService,
+        dataverseApi: widget.dataverseApi,
+        onLogout: _handleLogout,
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Login Azure AD (PKCE)'),
+      ),
+      body: Center(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: <Widget>[
+              const Icon(Icons.lock_outline, size: 72),
+              const SizedBox(height: 16),
+              Text(
+                'Inicia sesión con Authorization Code + PKCE.',
+                textAlign: TextAlign.center,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'TENANT: ${AuthConfig.tenantId}\nCLIENT_ID: ${AuthConfig.clientId}',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 24),
+              if (kIsWeb)
+                const Card(
+                  color: Colors.amber,
+                  child: Padding(
+                    padding: EdgeInsets.all(16),
+                    child: Text(
+                      'TODO Web: integra MSAL (msal-browser) o implementa un flujo PKCE manual. '
+                      'flutter_appauth no soporta Web.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                ),
+              const SizedBox(height: 12),
+              FilledButton.icon(
+                onPressed: _isProcessing ? null : _login,
+                icon: _isProcessing
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.login),
+                label: Text(_isProcessing ? 'Conectando...' : 'Login con Azure AD'),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Scopes configurados:\n${AuthConfig.scopes.join('\n')}',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                'Recuerda conceder permisos “Admin consent” al scope '.
+                'https://<ORG>.crm.dynamics.com/.default.',
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/lib/models/ticket.dart
+++ b/lib/models/ticket.dart
@@ -1,0 +1,55 @@
+class Ticket {
+  const Ticket({
+    required this.id,
+    required this.title,
+    required this.priority,
+    required this.status,
+  });
+
+  final String id;
+  final String title;
+  final String priority;
+  final String status;
+
+  factory Ticket.fromJson(Map<String, dynamic> json) {
+    return Ticket(
+      id: json['new_ticketid'] as String? ?? '',
+      title: json['new_title'] as String? ?? '',
+      priority: json['new_priority'] as String? ?? '',
+      status: json['new_status'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'new_ticketid': id,
+        'new_title': title,
+        'new_priority': priority,
+        'new_status': status,
+      };
+
+  Map<String, dynamic> toCreatePayload() => <String, dynamic>{
+        'new_title': title,
+        'new_priority': priority,
+        'new_status': status,
+      };
+
+  Map<String, dynamic> toUpdatePayload() => <String, dynamic>{
+        if (title.isNotEmpty) 'new_title': title,
+        if (priority.isNotEmpty) 'new_priority': priority,
+        if (status.isNotEmpty) 'new_status': status,
+      };
+
+  Ticket copyWith({
+    String? id,
+    String? title,
+    String? priority,
+    String? status,
+  }) {
+    return Ticket(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      priority: priority ?? this.priority,
+      status: status ?? this.status,
+    );
+  }
+}

--- a/lib/pages/example_page.dart
+++ b/lib/pages/example_page.dart
@@ -1,0 +1,440 @@
+import 'package:flutter/material.dart';
+
+import '../models/ticket.dart';
+import '../services/auth_service.dart';
+import '../services/dataverse_api.dart';
+
+class ExamplePage extends StatefulWidget {
+  const ExamplePage({
+    super.key,
+    required this.authService,
+    required this.dataverseApi,
+    required this.onLogout,
+  });
+
+  final AuthService authService;
+  final DataverseApi dataverseApi;
+  final VoidCallback onLogout;
+
+  @override
+  State<ExamplePage> createState() => _ExamplePageState();
+}
+
+class _ExamplePageState extends State<ExamplePage> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _priorityController = TextEditingController();
+  final TextEditingController _statusController = TextEditingController();
+
+  bool _isLoadingTickets = false;
+  bool _isCreating = false;
+  List<Ticket> _tickets = <Ticket>[];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadTickets();
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _priorityController.dispose();
+    _statusController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadTickets() async {
+    setState(() {
+      _isLoadingTickets = true;
+    });
+    try {
+      final List<Ticket> tickets = await widget.dataverseApi.getTickets();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _tickets = tickets;
+      });
+    } catch (error) {
+      _showErrorSnackBar('No fue posible cargar los tickets: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoadingTickets = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _createTicket() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+
+    setState(() {
+      _isCreating = true;
+    });
+
+    final String title = _titleController.text.trim();
+    final String priority = _priorityController.text.trim();
+    final String status = _statusController.text.trim();
+
+    try {
+      final Ticket ticket = await widget.dataverseApi.createTicket(
+        title: title,
+        priority: priority,
+        status: status,
+      );
+      if (!mounted) {
+        return;
+      }
+      _titleController.clear();
+      _priorityController.clear();
+      _statusController.clear();
+      setState(() {
+        _tickets = <Ticket>[ticket, ..._tickets];
+      });
+      _showSnackBar('Ticket creado correctamente.');
+    } catch (error) {
+      _showErrorSnackBar('No fue posible crear el ticket: $error');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isCreating = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _showEditDialog(Ticket ticket) async {
+    final TextEditingController titleController =
+        TextEditingController(text: ticket.title);
+    final TextEditingController priorityController =
+        TextEditingController(text: ticket.priority);
+    final TextEditingController statusController =
+        TextEditingController(text: ticket.status);
+    final GlobalKey<FormState> editFormKey = GlobalKey<FormState>();
+    bool isSaving = false;
+
+    final bool? updated = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return StatefulBuilder(
+          builder: (BuildContext context, void Function(void Function()) setStateDialog) {
+            return AlertDialog(
+              title: const Text('Editar ticket'),
+              content: Form(
+                key: editFormKey,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    TextFormField(
+                      controller: titleController,
+                      decoration: const InputDecoration(labelText: 'Título'),
+                      validator: _requiredValidator,
+                    ),
+                    TextFormField(
+                      controller: priorityController,
+                      decoration: const InputDecoration(labelText: 'Prioridad'),
+                      validator: _requiredValidator,
+                    ),
+                    TextFormField(
+                      controller: statusController,
+                      decoration: const InputDecoration(labelText: 'Estado'),
+                      validator: _requiredValidator,
+                    ),
+                  ],
+                ),
+              ),
+              actions: <Widget>[
+                TextButton(
+                  onPressed: isSaving ? null : () => Navigator.of(context).pop(false),
+                  child: const Text('Cancelar'),
+                ),
+                FilledButton(
+                  onPressed: isSaving
+                      ? null
+                      : () async {
+                          if (!editFormKey.currentState!.validate()) {
+                            return;
+                          }
+                          setStateDialog(() {
+                            isSaving = true;
+                          });
+                          try {
+                            await widget.dataverseApi.updateTicket(
+                              ticket.id,
+                              title: titleController.text.trim(),
+                              priority: priorityController.text.trim(),
+                              status: statusController.text.trim(),
+                            );
+                            if (mounted) {
+                              _showSnackBar('Ticket actualizado.');
+                            }
+                            if (context.mounted) {
+                              Navigator.of(context).pop(true);
+                            }
+                          } catch (error) {
+                            if (mounted) {
+                              _showErrorSnackBar('Error al actualizar: $error');
+                            }
+                            setStateDialog(() {
+                              isSaving = false;
+                            });
+                          }
+                        },
+                  child: isSaving
+                      ? const SizedBox(
+                          height: 16,
+                          width: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Guardar'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+
+    if (updated == true) {
+      await _loadTickets();
+    }
+
+    titleController.dispose();
+    priorityController.dispose();
+    statusController.dispose();
+  }
+
+  Future<void> _confirmDelete(Ticket ticket) async {
+    final bool? shouldDelete = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Eliminar ticket'),
+          content: Text('¿Eliminar "${ticket.title}"?'),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancelar'),
+            ),
+            FilledButton.icon(
+              onPressed: () => Navigator.of(context).pop(true),
+              icon: const Icon(Icons.delete_forever),
+              label: const Text('Eliminar'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shouldDelete == true) {
+      try {
+        await widget.dataverseApi.deleteTicket(ticket.id);
+        if (!mounted) {
+          return;
+        }
+        setState(() {
+          _tickets = _tickets.where((Ticket t) => t.id != ticket.id).toList();
+        });
+        _showSnackBar('Ticket eliminado.');
+      } catch (error) {
+        _showErrorSnackBar('No fue posible eliminar el ticket: $error');
+      }
+    }
+  }
+
+  Future<void> _logout() async {
+    try {
+      await widget.authService.logout();
+      if (!mounted) {
+        return;
+      }
+      _showSnackBar('Sesión cerrada.');
+    } finally {
+      widget.onLogout();
+    }
+  }
+
+  String? _requiredValidator(String? value) {
+    if (value == null || value.trim().isEmpty) {
+      return 'Campo obligatorio';
+    }
+    return null;
+  }
+
+  void _showSnackBar(String message) {
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
+  }
+
+  void _showErrorSnackBar(String message) {
+    if (!mounted) {
+      return;
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: Theme.of(context).colorScheme.error,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    final Widget listContent = _isLoadingTickets && _tickets.isEmpty
+        ? const Center(child: CircularProgressIndicator())
+        : RefreshIndicator(
+            onRefresh: _loadTickets,
+            child: ListView(
+              padding: const EdgeInsets.all(16),
+              physics: const AlwaysScrollableScrollPhysics(),
+              children: <Widget>[
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          'Test de humo',
+                          style: theme.textTheme.titleMedium,
+                        ),
+                        const SizedBox(height: 8),
+                        const Text(
+                          '1. Pulsa "Crear ticket" tras iniciar sesión para ejecutar createTicket().\n'
+                          '2. La lista inferior usa getTickets() tras el login.\n'
+                          '3. Usa los botones de cada item para PATCH/DELETE.',
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Form(
+                      key: _formKey,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            'Crear ticket',
+                            style: theme.textTheme.titleMedium,
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            controller: _titleController,
+                            decoration: const InputDecoration(
+                              labelText: 'Título',
+                              hintText: 'Ej. Falla en impresora',
+                            ),
+                            validator: _requiredValidator,
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            controller: _priorityController,
+                            decoration: const InputDecoration(
+                              labelText: 'Prioridad',
+                              hintText: 'Ej. Alta',
+                            ),
+                            validator: _requiredValidator,
+                          ),
+                          const SizedBox(height: 12),
+                          TextFormField(
+                            controller: _statusController,
+                            decoration: const InputDecoration(
+                              labelText: 'Estado',
+                              hintText: 'Ej. Abierto',
+                            ),
+                            validator: _requiredValidator,
+                          ),
+                          const SizedBox(height: 16),
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: FilledButton.icon(
+                              onPressed: _isCreating ? null : _createTicket,
+                              icon: _isCreating
+                                  ? const SizedBox(
+                                      height: 16,
+                                      width: 16,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : const Icon(Icons.send),
+                              label: Text(_isCreating ? 'Guardando...' : 'Crear ticket'),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Tickets (${_tickets.length})',
+                  style: theme.textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                if (_tickets.isEmpty)
+                  const Card(
+                    child: Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Text('No hay tickets todavía.'),
+                    ),
+                  )
+                else
+                  ..._tickets.map(_buildTicketTile),
+              ],
+            ),
+          );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Azure AD + Dataverse (new_ticket)'),
+        actions: <Widget>[
+          IconButton(
+            tooltip: 'Cerrar sesión',
+            onPressed: _logout,
+            icon: const Icon(Icons.logout),
+          ),
+        ],
+      ),
+      body: SafeArea(child: listContent),
+    );
+  }
+
+  Widget _buildTicketTile(Ticket ticket) {
+    return Card(
+      child: ListTile(
+        title: Text(ticket.title.isEmpty ? '(Sin título)' : ticket.title),
+        subtitle: Text('Prioridad: ${ticket.priority} | Estado: ${ticket.status}'),
+        trailing: Wrap(
+          spacing: 8,
+          children: <Widget>[
+            IconButton(
+              tooltip: 'Editar',
+              onPressed: () => _showEditDialog(ticket),
+              icon: const Icon(Icons.edit),
+            ),
+            IconButton(
+              tooltip: 'Eliminar',
+              onPressed: () => _confirmDelete(ticket),
+              icon: const Icon(Icons.delete),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,216 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import '../config/auth_config.dart';
+
+class AuthService {
+  AuthService({
+    FlutterAppAuth? appAuth,
+    FlutterSecureStorage? secureStorage,
+    DateTime Function()? now,
+  })  : _appAuth = appAuth ?? const FlutterAppAuth(),
+        _secureStorage = secureStorage ?? const FlutterSecureStorage(),
+        _now = now ?? DateTime.now;
+
+  final FlutterAppAuth _appAuth;
+  final FlutterSecureStorage _secureStorage;
+  final DateTime Function() _now;
+
+  static const String _accessTokenKey = 'auth_access_token';
+  static const String _refreshTokenKey = 'auth_refresh_token';
+  static const String _expiryKey = 'auth_access_token_expiry';
+
+  Future<void> login() async {
+    if (kIsWeb) {
+      throw AuthException(
+        'TODO: usa MSAL (msal-browser) o implementa un flujo PKCE manual para Web.',
+      );
+    }
+
+    try {
+      final AuthorizationTokenResponse? response =
+          await _appAuth.authorizeAndExchangeCode(
+        AuthorizationTokenRequest(
+          AuthConfig.clientId,
+          AuthConfig.redirectUriForPlatform(),
+          serviceConfiguration: AuthorizationServiceConfiguration(
+            authorizationEndpoint: AuthConfig.authorizationEndpoint,
+            tokenEndpoint: AuthConfig.tokenEndpoint,
+          ),
+          scopes: AuthConfig.scopes,
+          promptValues: const <String>['select_account'],
+        ),
+      );
+
+      if (response == null || response.accessToken == null) {
+        throw const AuthException(
+          'No se recibió un accessToken válido durante el inicio de sesión.',
+        );
+      }
+
+      await _persistTokens(
+        accessToken: response.accessToken!,
+        refreshToken: response.refreshToken,
+        expiry: response.accessTokenExpirationDateTime ??
+            _now().toUtc().add(const Duration(hours: 1)),
+      );
+    } on AuthException {
+      rethrow;
+    } catch (error) {
+      await logout();
+      throw AuthException('Error durante el inicio de sesión: $error', error);
+    }
+  }
+
+  Future<void> refreshIfNeeded() async {
+    final DateTime? expiry = await _readExpiry();
+    if (expiry == null) {
+      return;
+    }
+
+    final Duration difference = expiry.difference(_now().toUtc());
+    if (difference.inSeconds > 60) {
+      return;
+    }
+
+    await _refreshToken();
+  }
+
+  Future<void> logout() async {
+    await Future.wait(<Future<void>>[
+      _secureStorage.delete(key: _accessTokenKey),
+      _secureStorage.delete(key: _refreshTokenKey),
+      _secureStorage.delete(key: _expiryKey),
+    ]);
+  }
+
+  Future<String> getAccessToken() async {
+    await refreshIfNeeded();
+    final String? accessToken =
+        await _secureStorage.read(key: _accessTokenKey);
+
+    if (accessToken == null || accessToken.isEmpty) {
+      throw const AuthException('No hay una sesión válida. Ejecuta login().');
+    }
+    return accessToken;
+  }
+
+  Future<bool> hasValidSession() async {
+    final String? accessToken =
+        await _secureStorage.read(key: _accessTokenKey);
+    final DateTime? expiry = await _readExpiry();
+
+    if (accessToken == null || accessToken.isEmpty || expiry == null) {
+      return false;
+    }
+
+    if (expiry.isBefore(_now().toUtc())) {
+      try {
+        await _refreshToken();
+      } on AuthException {
+        return false;
+      }
+    } else {
+      try {
+        await refreshIfNeeded();
+      } on AuthException {
+        return false;
+      }
+    }
+
+    final String? refreshedToken =
+        await _secureStorage.read(key: _accessTokenKey);
+    return refreshedToken != null && refreshedToken.isNotEmpty;
+  }
+
+  Future<void> _refreshToken() async {
+    if (kIsWeb) {
+      throw AuthException(
+        'TODO: usa MSAL (msal-browser) o implementa un flujo PKCE manual para Web.',
+      );
+    }
+
+    final String? storedRefreshToken =
+        await _secureStorage.read(key: _refreshTokenKey);
+    if (storedRefreshToken == null || storedRefreshToken.isEmpty) {
+      throw const AuthException(
+        'No hay refresh_token disponible. Inicia sesión nuevamente.',
+      );
+    }
+
+    try {
+      final TokenResponse? response = await _appAuth.token(
+        TokenRequest(
+          AuthConfig.clientId,
+          AuthConfig.redirectUriForPlatform(),
+          refreshToken: storedRefreshToken,
+          serviceConfiguration: AuthorizationServiceConfiguration(
+            authorizationEndpoint: AuthConfig.authorizationEndpoint,
+            tokenEndpoint: AuthConfig.tokenEndpoint,
+          ),
+          scopes: AuthConfig.scopes,
+        ),
+      );
+
+      if (response == null || response.accessToken == null) {
+        throw const AuthException(
+          'No se recibió un accessToken válido al refrescar.',
+        );
+      }
+
+      await _persistTokens(
+        accessToken: response.accessToken!,
+        refreshToken: response.refreshToken ?? storedRefreshToken,
+        expiry: response.accessTokenExpirationDateTime ??
+            _now().toUtc().add(const Duration(hours: 1)),
+      );
+    } on AuthException {
+      rethrow;
+    } catch (error) {
+      await logout();
+      throw AuthException('Error al refrescar el token: $error', error);
+    }
+  }
+
+  Future<void> _persistTokens({
+    required String accessToken,
+    String? refreshToken,
+    required DateTime expiry,
+  }) async {
+    await _secureStorage.write(key: _accessTokenKey, value: accessToken);
+    if (refreshToken != null && refreshToken.isNotEmpty) {
+      await _secureStorage.write(
+        key: _refreshTokenKey,
+        value: refreshToken,
+      );
+    }
+    await _secureStorage.write(
+      key: _expiryKey,
+      value: expiry.toUtc().toIso8601String(),
+    );
+  }
+
+  Future<DateTime?> _readExpiry() async {
+    final String? storedExpiry = await _secureStorage.read(key: _expiryKey);
+    if (storedExpiry == null) {
+      return null;
+    }
+    try {
+      return DateTime.parse(storedExpiry).toUtc();
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+class AuthException implements Exception {
+  const AuthException(this.message, [this.cause]);
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() =>
+      'AuthException: $message${cause != null ? ' (causa: $cause)' : ''}';
+}

--- a/lib/services/dataverse_api.dart
+++ b/lib/services/dataverse_api.dart
@@ -1,0 +1,239 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../config/auth_config.dart';
+import '../models/ticket.dart';
+import 'auth_service.dart';
+
+class DataverseApi {
+  DataverseApi({
+    AuthService? authService,
+    http.Client? httpClient,
+  })  : _authService = authService ?? AuthService(),
+        _httpClient = httpClient ?? http.Client();
+
+  final AuthService _authService;
+  final http.Client _httpClient;
+
+  static Uri get _collectionUri =>
+      Uri.parse('${AuthConfig.organizationHost}/api/data/v9.2/new_tickets');
+
+  Future<List<Ticket>> getTickets({
+    int top = 20,
+    String? filter,
+    String? orderBy,
+  }) async {
+    final List<Ticket> tickets = <Ticket>[];
+    Uri? requestUri = _buildListUri(top: top, filter: filter, orderBy: orderBy);
+
+    while (requestUri != null) {
+      final http.Response response = await _authorizedGet(requestUri);
+      final Map<String, dynamic> decoded = _decodeJson(response);
+      final Iterable<dynamic> rawValues = decoded['value'] as Iterable<dynamic>? ??
+          const <dynamic>[];
+      tickets.addAll(
+        rawValues
+            .whereType<Map<String, dynamic>>()
+            .map(Ticket.fromJson),
+      );
+
+      final String? nextLink = decoded['@odata.nextLink'] as String?;
+      if (nextLink == null || nextLink.isEmpty) {
+        requestUri = null;
+      } else {
+        requestUri = Uri.parse(nextLink);
+      }
+    }
+
+    return tickets;
+  }
+
+  Future<Ticket> createTicket({
+    required String title,
+    required String priority,
+    required String status,
+  }) async {
+    final String token = await _authService.getAccessToken();
+    final http.Response response = await _httpClient.post(
+      _collectionUri,
+      headers: _headers(token),
+      body: jsonEncode(<String, dynamic>{
+        'new_title': title,
+        'new_priority': priority,
+        'new_status': status,
+      }),
+    );
+
+    _ensureSuccess(response);
+
+    if (response.body.isNotEmpty) {
+      final Map<String, dynamic> decoded = _decodeJson(response);
+      return Ticket.fromJson(decoded);
+    }
+
+    final String? entityId = response.headers['odata-entityid'];
+    final String? ticketId = _extractGuid(entityId);
+
+    return Ticket(
+      id: ticketId ?? '',
+      title: title,
+      priority: priority,
+      status: status,
+    );
+  }
+
+  Future<void> updateTicket(
+    String id, {
+    String? title,
+    String? priority,
+    String? status,
+  }) async {
+    final Map<String, dynamic> updates = <String, dynamic>{};
+    if (title != null) {
+      updates['new_title'] = title;
+    }
+    if (priority != null) {
+      updates['new_priority'] = priority;
+    }
+    if (status != null) {
+      updates['new_status'] = status;
+    }
+
+    if (updates.isEmpty) {
+      return;
+    }
+
+    final String token = await _authService.getAccessToken();
+    final Uri resourceUri = _ticketUri(id);
+    final http.Response response = await _httpClient.patch(
+      resourceUri,
+      headers: _headers(token),
+      body: jsonEncode(updates),
+    );
+
+    _ensureSuccess(response);
+  }
+
+  Future<void> deleteTicket(String id) async {
+    final String token = await _authService.getAccessToken();
+    final Uri resourceUri = _ticketUri(id);
+    final http.Response response = await _httpClient.delete(
+      resourceUri,
+      headers: _headers(token),
+    );
+
+    _ensureSuccess(response);
+  }
+
+  void dispose() {
+    _httpClient.close();
+  }
+
+  Uri _buildListUri({
+    required int top,
+    String? filter,
+    String? orderBy,
+  }) {
+    final String dollar = String.fromCharCode(36);
+    final Map<String, String> queryParameters = <String, String>{
+      '${dollar}select': 'new_title,new_priority,new_status,new_ticketid',
+      '${dollar}top': top.toString(),
+    };
+
+    if (filter != null && filter.isNotEmpty) {
+      queryParameters['${dollar}filter'] = filter;
+    }
+
+    if (orderBy != null && orderBy.isNotEmpty) {
+      queryParameters['${dollar}orderby'] = orderBy;
+    }
+
+    return _collectionUri.replace(queryParameters: queryParameters);
+  }
+
+  Future<http.Response> _authorizedGet(Uri uri) async {
+    final String token = await _authService.getAccessToken();
+    final http.Response response = await _httpClient.get(
+      uri,
+      headers: _headers(token),
+    );
+    _ensureSuccess(response);
+    return response;
+  }
+
+  Uri _ticketUri(String id) {
+    final String trimmedId = id.replaceAll('{', '').replaceAll('}', '');
+    return Uri.parse('${AuthConfig.organizationHost}/api/data/v9.2/new_tickets($trimmedId)');
+  }
+
+  Map<String, String> _headers(String token) => <String, String>{
+        'Authorization': 'Bearer $token',
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'OData-Version': '4.0',
+      };
+
+  Map<String, dynamic> _decodeJson(http.Response response) {
+    if (response.bodyBytes.isEmpty) {
+      return const <String, dynamic>{};
+    }
+    final String content = utf8.decode(response.bodyBytes);
+    if (content.isEmpty) {
+      return const <String, dynamic>{};
+    }
+    return jsonDecode(content) as Map<String, dynamic>;
+  }
+
+  void _ensureSuccess(http.Response response) {
+    final bool isSuccess = response.statusCode >= 200 && response.statusCode < 300;
+    if (isSuccess) {
+      return;
+    }
+
+    final String details = _extractError(response);
+    throw DataverseApiException(
+      'Error ${response.statusCode} al llamar a Dataverse: $details',
+    );
+  }
+
+  String _extractError(http.Response response) {
+    if (response.bodyBytes.isEmpty) {
+      return response.reasonPhrase ?? 'Respuesta vacía';
+    }
+
+    try {
+      final Map<String, dynamic> decoded =
+          jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+      final dynamic error = decoded['error'];
+      if (error is Map<String, dynamic>) {
+        final String? message = error['message'] as String?;
+        return message ?? decoded.toString();
+      }
+      return decoded.toString();
+    } catch (_) {
+      return utf8.decode(response.bodyBytes);
+    }
+  }
+
+  String? _extractGuid(String? entityId) {
+    if (entityId == null) {
+      return null;
+    }
+    final RegExpMatch? match =
+        RegExp(r'([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})')
+            .firstMatch(entityId);
+    return match?.group(1);
+  }
+}
+
+class DataverseApiException implements Exception {
+  DataverseApiException(this.message, [this.cause]);
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() =>
+      'DataverseApiException: $message${cause != null ? ' (causa: $cause)' : ''}';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,10 @@ dependencies:
   shimmer: ^3.0.0
   shared_preferences: ^2.2.2
   crypto: ^3.0.3
+  # Azure AD + Dataverse
+  flutter_appauth: ^6.0.0
+  http: ^1.2.0
+  flutter_secure_storage: ^9.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Azure AD and Dataverse configuration constants plus secure token management with flutter_appauth
- implement Dataverse API client, ticket model, and demo UI covering login, CRUD, and pagination
- update app entrypoint, dependencies, and mobile platform manifests for PKCE redirect URIs

## Testing
- `dart format .` *(fails: flutter/dart SDK unavailable in container)*
- `flutter test` *(fails: flutter CLI unavailable in container)*
- `flutter build apk` *(fails: flutter CLI unavailable in container)*
- `flutter build ipa` *(fails: flutter CLI unavailable in container)*


------
https://chatgpt.com/codex/tasks/task_e_68d22e038b748320808de72c847c0f76