### PR TITLE
Add web preview mode toggle for auth and tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
-# sistema_tickets_edis
+# Sistema Tickets y EDIs
 
-A new Flutter project.
+Demo en Flutter para autenticarse contra Azure AD y consumir Dataverse.
 
-## Getting Started
+## Modo demo web sin conexión
 
-This project is a starting point for a Flutter application.
+Puedes navegar por la interfaz sin configurar Azure ni Dataverse compilando con el flag `WEB_PREVIEW`:
 
-A few resources to get you started if this is your first Flutter project:
+```bash
+flutter run -d chrome --dart-define=WEB_PREVIEW=true
+# o bien
+flutter build web --dart-define=WEB_PREVIEW=true
+```
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+En este modo:
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+- La pantalla principal se muestra sin requerir login con Azure AD.
+- Los tickets se almacenan en memoria local (no se envían a Dataverse).
+- Puedes crear, editar y eliminar tickets de demostración para validar el flujo UI.
+
+Compila sin el flag para restaurar la integración real con Azure AD + Dataverse.

--- a/lib/app/providers.dart
+++ b/lib/app/providers.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:sistema_tickets_edis/core/notifications/local_notification_service.dart';
+import 'package:sistema_tickets_edis/core/notifications/notification_service.dart';
 import 'package:sistema_tickets_edis/core/pdf/alta_document_service.dart';
 import 'package:sistema_tickets_edis/data/local/database/app_database.dart';
 import 'package:sistema_tickets_edis/data/repositories/auth_repository_impl.dart';
@@ -22,8 +22,8 @@ final appDatabaseProvider = Provider<AppDatabase>((ProviderRef<AppDatabase> ref)
   throw UnimplementedError('AppDatabase debe inyectarse desde bootstrap.');
 });
 
-final localNotificationServiceProvider = Provider<LocalNotificationService>((ref) {
-  throw UnimplementedError('LocalNotificationService debe inyectarse desde bootstrap.');
+final localNotificationServiceProvider = Provider<NotificationService>((ref) {
+  throw UnimplementedError('NotificationService debe inyectarse desde bootstrap.');
 });
 
 final altaDocumentServiceProvider = Provider<AltaDocumentService>((ref) {
@@ -47,7 +47,7 @@ final ticketWorkflowServiceProvider = Provider<TicketWorkflowService>((ref) {
 final ticketRepositoryProvider = Provider<TicketRepository>((ref) {
   final AppDatabase database = ref.watch(appDatabaseProvider);
   final TicketWorkflowService workflow = ref.watch(ticketWorkflowServiceProvider);
-  final LocalNotificationService notifications = ref.watch(localNotificationServiceProvider);
+  final NotificationService notifications = ref.watch(localNotificationServiceProvider);
   final AltaDocumentService altaService = ref.watch(altaDocumentServiceProvider);
   return TicketRepositoryImpl(
     database: database,

--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -5,13 +6,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:sistema_tickets_edis/app/app.dart';
 import 'package:sistema_tickets_edis/app/providers.dart';
 import 'package:sistema_tickets_edis/core/notifications/local_notification_service.dart';
+import 'package:sistema_tickets_edis/core/notifications/notification_service.dart';
+import 'package:sistema_tickets_edis/core/notifications/web_notification_service.dart';
 import 'package:sistema_tickets_edis/core/pdf/alta_document_service.dart';
 import 'package:sistema_tickets_edis/data/local/database/app_database.dart';
 
 Future<void> bootstrap() async {
   WidgetsFlutterBinding.ensureInitialized();
   final AppDatabase database = AppDatabase();
-  final LocalNotificationService notifications = LocalNotificationService();
+  final NotificationService notifications =
+      kIsWeb ? WebNotificationService() : LocalNotificationService();
   await notifications.initialize();
   final AltaDocumentService altaService = AltaDocumentService();
   final SharedPreferences preferences = await SharedPreferences.getInstance();

--- a/lib/config/auth_config.dart
+++ b/lib/config/auth_config.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 /// - [organizationHost]: URL base de Dataverse (termina con .crm.dynamics.com).
 /// - [redirectUriAndroid] y [redirectUriIos]: deben coincidir con los Redirect URIs
 ///   configurados en el registro de la app.
+/// - [redirectUriWeb]: URI registrada para builds web (https://tuapp.com/auth).
 /// - [scopes]: incluye `.default` del recurso Dataverse y los scopes básicos.
 class AuthConfig {
   const AuthConfig._();
@@ -17,6 +18,7 @@ class AuthConfig {
   static const String organizationHost = 'https://<ORG>.crm.dynamics.com';
   static const String redirectUriAndroid = 'com.example.app:/oauthredirect';
   static const String redirectUriIos = 'com.example.app:/oauthredirect';
+  static const String redirectUriWeb = 'http://localhost:8080';
 
   /// Incluye `.default` para Dataverse y `offline_access` para refresh tokens.
   static const List<String> scopes = <String>[
@@ -37,15 +39,13 @@ class AuthConfig {
   static String get tokenEndpoint =>
       _tokenEndpointTemplate.replaceFirst('<TENANT_ID>', tenantId);
 
+  static String get authority =>
+      'https://login.microsoftonline.com/$tenantId';
+
   /// Devuelve el redirect URI correcto según la plataforma actual.
-  ///
-  /// Para Web se debe usar MSAL (msal-browser) o implementar un flujo PKCE
-  /// manual; `flutter_appauth` no soporta Web.
   static String redirectUriForPlatform() {
     if (kIsWeb) {
-      throw UnsupportedError(
-        'TODO: usar MSAL (msal-browser) o un flujo PKCE manual para Web.',
-      );
+      return redirectUriWeb;
     }
 
     switch (defaultTargetPlatform) {

--- a/lib/config/preview_config.dart
+++ b/lib/config/preview_config.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/foundation.dart';
+
+/// Flags de compilación para habilitar el modo de previsualización sin backend.
+const bool kWebPreviewFlag = bool.fromEnvironment('WEB_PREVIEW', defaultValue: false);
+
+/// Indica si la aplicación debe ejecutar el modo demo sin conectarse a Azure/Dataverse.
+bool get kUsePreviewBackend => kIsWeb && kWebPreviewFlag;
+

--- a/lib/core/notifications/local_notification_service.dart
+++ b/lib/core/notifications/local_notification_service.dart
@@ -5,14 +5,17 @@ import 'package:timezone/timezone.dart' as tz;
 import 'package:sistema_tickets_edis/domain/entities/ticket.dart';
 import 'package:sistema_tickets_edis/domain/entities/ticket_event.dart';
 
+import 'notification_service.dart';
+
 /// Wrapper around [FlutterLocalNotificationsPlugin] with domain-specific helpers.
-class LocalNotificationService {
+class LocalNotificationService implements NotificationService {
   LocalNotificationService([FlutterLocalNotificationsPlugin? plugin])
     : _plugin = plugin ?? FlutterLocalNotificationsPlugin();
 
   final FlutterLocalNotificationsPlugin _plugin;
   Future<void> Function(String token)? onFcmToken;
 
+  @override
   Future<void> initialize() async {
     tz_data.initializeTimeZones();
     const AndroidInitializationSettings androidSettings =
@@ -44,6 +47,7 @@ class LocalNotificationService {
     return const NotificationDetails(android: androidDetails, iOS: iosDetails);
   }
 
+  @override
   Future<void> showTicketCreated(Ticket ticket) {
     return _plugin.show(
       ticket.id,
@@ -53,6 +57,7 @@ class LocalNotificationService {
     );
   }
 
+  @override
   Future<void> showStatusChanged(Ticket ticket, TicketEvent event) {
     return _plugin.show(
       ticket.id * 100,
@@ -62,6 +67,7 @@ class LocalNotificationService {
     );
   }
 
+  @override
   Future<void> showAssignment(Ticket ticket, String technicianName) {
     return _plugin.show(
       ticket.id * 200,
@@ -71,6 +77,7 @@ class LocalNotificationService {
     );
   }
 
+  @override
   Future<void> scheduleReminder({
     required int ticketId,
     required DateTime when,
@@ -91,6 +98,7 @@ class LocalNotificationService {
   }
 
   /// Stores a callback that will be triggered when an FCM token is available.
+  @override
   void registerFcmTokenHandler(Future<void> Function(String token) handler) {
     onFcmToken = handler;
   }

--- a/lib/core/notifications/notification_service.dart
+++ b/lib/core/notifications/notification_service.dart
@@ -1,0 +1,21 @@
+import 'package:sistema_tickets_edis/domain/entities/ticket.dart';
+import 'package:sistema_tickets_edis/domain/entities/ticket_event.dart';
+
+/// Contrato genérico para enviar notificaciones al usuario final.
+abstract class NotificationService {
+  Future<void> initialize();
+
+  Future<void> showTicketCreated(Ticket ticket);
+
+  Future<void> showStatusChanged(Ticket ticket, TicketEvent event);
+
+  Future<void> showAssignment(Ticket ticket, String technicianName);
+
+  Future<void> scheduleReminder({
+    required int ticketId,
+    required DateTime when,
+    String? message,
+  });
+
+  void registerFcmTokenHandler(Future<void> Function(String token) handler) {}
+}

--- a/lib/core/notifications/web_notification_service.dart
+++ b/lib/core/notifications/web_notification_service.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:html' as html;
+
+import 'package:sistema_tickets_edis/domain/entities/ticket.dart';
+import 'package:sistema_tickets_edis/domain/entities/ticket_event.dart';
+
+import 'notification_service.dart';
+
+class WebNotificationService implements NotificationService {
+  final List<Timer> _timers = <Timer>[];
+
+  bool get _supported => html.Notification.supported;
+
+  bool get _permissionGranted => html.Notification.permission == 'granted';
+
+  @override
+  Future<void> initialize() async {
+    if (!_supported) {
+      return;
+    }
+    if (html.Notification.permission == 'default') {
+      await html.Notification.requestPermission();
+    }
+  }
+
+  @override
+  Future<void> showTicketCreated(Ticket ticket) async {
+    await _ensurePermission();
+    _show(
+      'Nuevo ticket ${ticket.folio}',
+      '${ticket.requesterName}: ${ticket.title}',
+    );
+  }
+
+  @override
+  Future<void> showStatusChanged(Ticket ticket, TicketEvent event) async {
+    await _ensurePermission();
+    _show(
+      'Ticket ${ticket.folio} ${ticket.status.label}',
+      event.message,
+    );
+  }
+
+  @override
+  Future<void> showAssignment(Ticket ticket, String technicianName) async {
+    await _ensurePermission();
+    _show(
+      'Asignado a $technicianName',
+      'Ticket ${ticket.folio} asignado.',
+    );
+  }
+
+  @override
+  Future<void> scheduleReminder({
+    required int ticketId,
+    required DateTime when,
+    String? message,
+  }) async {
+    if (!_supported) {
+      return;
+    }
+    await _ensurePermission();
+    if (!_permissionGranted) {
+      return;
+    }
+    final Duration delay = when.difference(DateTime.now());
+    if (delay.isNegative || delay.inSeconds == 0) {
+      _show('Seguimiento ticket', message ?? 'Revisión pendiente del ticket #$ticketId');
+      return;
+    }
+    _timers.add(
+      Timer(delay, () {
+        _show(
+          'Seguimiento ticket',
+          message ?? 'Revisión pendiente del ticket #$ticketId',
+        );
+      }),
+    );
+  }
+
+  @override
+  void registerFcmTokenHandler(Future<void> Function(String token) handler) {
+    // No-op en web.
+  }
+
+  Future<void> _ensurePermission() async {
+    if (!_supported) {
+      return;
+    }
+    if (!_permissionGranted) {
+      await html.Notification.requestPermission();
+    }
+  }
+
+  void _show(String title, String body) {
+    if (!_supported || !_permissionGranted) {
+      return;
+    }
+    html.Notification(title, body: body);
+  }
+}

--- a/lib/core/pdf/storage/alta_document_storage.dart
+++ b/lib/core/pdf/storage/alta_document_storage.dart
@@ -1,0 +1,19 @@
+import 'dart:typed_data';
+
+import 'package:sistema_tickets_edis/domain/entities/alta_document_result.dart';
+import 'package:sistema_tickets_edis/domain/entities/ticket.dart';
+
+import 'alta_document_storage_stub.dart'
+    if (dart.library.html) 'alta_document_storage_web.dart'
+    if (dart.library.io) 'alta_document_storage_io.dart';
+
+abstract class AltaDocumentStorage {
+  Future<AltaDocumentResult> save({
+    required Ticket ticket,
+    required String baseName,
+    required Uint8List pdfBytes,
+    required String csvData,
+  });
+}
+
+AltaDocumentStorage createAltaDocumentStorage() => createAltaDocumentStorageImpl();

--- a/lib/core/pdf/storage/alta_document_storage_io.dart
+++ b/lib/core/pdf/storage/alta_document_storage_io.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'package:sistema_tickets_edis/domain/entities/alta_document_result.dart';
+import 'package:sistema_tickets_edis/domain/entities/ticket.dart';
+
+import 'alta_document_storage.dart';
+
+class FileSystemAltaDocumentStorage implements AltaDocumentStorage {
+  FileSystemAltaDocumentStorage({Future<Directory> Function()? directoryBuilder})
+      : _directoryBuilder = directoryBuilder ?? _defaultDirectoryBuilder;
+
+  final Future<Directory> Function() _directoryBuilder;
+
+  static Future<Directory> _defaultDirectoryBuilder() async {
+    try {
+      final Directory base = await getApplicationDocumentsDirectory();
+      final Directory target = Directory(p.join(base.path, 'rm_fg_docs'));
+      if (!await target.exists()) {
+        await target.create(recursive: true);
+      }
+      return target;
+    } catch (_) {
+      final Directory fallback =
+          await Directory.systemTemp.createTemp('rm_fg_docs');
+      return fallback;
+    }
+  }
+
+  @override
+  Future<AltaDocumentResult> save({
+    required Ticket ticket,
+    required String baseName,
+    required Uint8List pdfBytes,
+    required String csvData,
+  }) async {
+    final Directory directory = await _directoryBuilder();
+    final String pdfFileName = '$baseName.pdf';
+    final String csvFileName = '$baseName.csv';
+
+    final File pdfFile = File(p.join(directory.path, pdfFileName));
+    await pdfFile.writeAsBytes(pdfBytes);
+    final File csvFile = File(p.join(directory.path, csvFileName));
+    await csvFile.writeAsString(csvData);
+
+    return AltaDocumentResult(
+      pdf: AltaDocumentArtifact(
+        reference: pdfFile.path,
+        fileName: pdfFileName,
+        mimeType: 'application/pdf',
+      ),
+      csv: AltaDocumentArtifact(
+        reference: csvFile.path,
+        fileName: csvFileName,
+        mimeType: 'text/csv',
+      ),
+    );
+  }
+}
+
+AltaDocumentStorage createAltaDocumentStorageImpl() =>
+    FileSystemAltaDocumentStorage();

--- a/lib/core/pdf/storage/alta_document_storage_stub.dart
+++ b/lib/core/pdf/storage/alta_document_storage_stub.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+
+import 'package:sistema_tickets_edis/domain/entities/alta_document_result.dart';
+import 'package:sistema_tickets_edis/domain/entities/ticket.dart';
+
+import 'alta_document_storage.dart';
+
+AltaDocumentStorage createAltaDocumentStorageImpl() =>
+    _UnsupportedAltaDocumentStorage();
+
+class _UnsupportedAltaDocumentStorage implements AltaDocumentStorage {
+  @override
+  Future<AltaDocumentResult> save({
+    required Ticket ticket,
+    required String baseName,
+    required Uint8List pdfBytes,
+    required String csvData,
+  }) async {
+    throw UnsupportedError('No hay almacenamiento disponible para documentos RM/FG.');
+  }
+}

--- a/lib/core/pdf/storage/alta_document_storage_web.dart
+++ b/lib/core/pdf/storage/alta_document_storage_web.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+import 'package:sistema_tickets_edis/domain/entities/alta_document_result.dart';
+import 'package:sistema_tickets_edis/domain/entities/ticket.dart';
+
+import 'alta_document_storage.dart';
+
+class WebAltaDocumentStorage implements AltaDocumentStorage {
+  @override
+  Future<AltaDocumentResult> save({
+    required Ticket ticket,
+    required String baseName,
+    required Uint8List pdfBytes,
+    required String csvData,
+  }) async {
+    final String pdfFileName = '$baseName.pdf';
+    final String csvFileName = '$baseName.csv';
+
+    final html.Blob pdfBlob = html.Blob(<dynamic>[pdfBytes], 'application/pdf');
+    final String pdfUrl = html.Url.createObjectUrl(pdfBlob);
+    _triggerDownload(pdfUrl, pdfFileName);
+
+    final html.Blob csvBlob = html.Blob(<dynamic>[csvData], 'text/csv');
+    final String csvUrl = html.Url.createObjectUrl(csvBlob);
+    _triggerDownload(csvUrl, csvFileName);
+
+    return AltaDocumentResult(
+      pdf: AltaDocumentArtifact(
+        reference: pdfUrl,
+        fileName: pdfFileName,
+        mimeType: 'application/pdf',
+      ),
+      csv: AltaDocumentArtifact(
+        reference: csvUrl,
+        fileName: csvFileName,
+        mimeType: 'text/csv',
+      ),
+    );
+  }
+
+  void _triggerDownload(String url, String fileName) {
+    final html.AnchorElement anchor = html.AnchorElement(href: url)
+      ..download = fileName
+      ..style.display = 'none';
+    html.document.body?.append(anchor);
+    anchor.click();
+    anchor.remove();
+    Timer(const Duration(seconds: 30), () => html.Url.revokeObjectUrl(url));
+  }
+}
+
+AltaDocumentStorage createAltaDocumentStorageImpl() => WebAltaDocumentStorage();

--- a/lib/data/local/database/app_database.dart
+++ b/lib/data/local/database/app_database.dart
@@ -1,35 +1,15 @@
 // lib/data/local/database/app_database.dart
-import 'dart:async';
-import 'dart:io';
-
 import 'package:collection/collection.dart';
 import 'package:drift/drift.dart';
-import 'package:drift/native.dart';
-import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
 
 import 'package:sistema_tickets_edis/domain/entities/catalog.dart';
 import 'package:sistema_tickets_edis/domain/entities/ticket_event.dart';
 import 'package:sistema_tickets_edis/domain/entities/technician.dart';
 import 'package:sistema_tickets_edis/domain/entities/user.dart';
 
-part 'app_database.g.dart';
+import 'connection/connection_factory.dart';
 
-/// Conexión perezosa a SQLite
-LazyDatabase _openConnection() {
-  return LazyDatabase(() async {
-    try {
-      final Directory dir = await getApplicationDocumentsDirectory();
-      final File file = File(p.join(dir.path, 'tickets.db'));
-      return NativeDatabase(file);
-    } catch (_) {
-      final Directory temp =
-          await Directory.systemTemp.createTemp('tickets_db');
-      final File file = File(p.join(temp.path, 'tickets.db'));
-      return NativeDatabase(file);
-    }
-  });
-}
+part 'app_database.g.dart';
 
 /// ========================
 /// Tablas Drift (fuente)
@@ -140,7 +120,8 @@ class DmfExports extends Table {
   ],
 )
 class AppDatabase extends _$AppDatabase {
-  AppDatabase({QueryExecutor? executor}) : super(executor ?? _openConnection());
+  AppDatabase({QueryExecutor? executor})
+      : super(executor ?? createDriftExecutor());
 
   @override
   int get schemaVersion => 1;

--- a/lib/data/local/database/connection/connection_factory.dart
+++ b/lib/data/local/database/connection/connection_factory.dart
@@ -1,0 +1,7 @@
+import 'package:drift/drift.dart';
+
+import 'connection_factory_stub.dart'
+    if (dart.library.html) 'connection_factory_web.dart'
+    if (dart.library.io) 'connection_factory_io.dart';
+
+QueryExecutor createDriftExecutor() => createExecutor();

--- a/lib/data/local/database/connection/connection_factory_io.dart
+++ b/lib/data/local/database/connection/connection_factory_io.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+QueryExecutor createExecutor() {
+  return LazyDatabase(() async {
+    try {
+      final Directory dir = await getApplicationDocumentsDirectory();
+      final File file = File(p.join(dir.path, 'tickets.db'));
+      return NativeDatabase(file);
+    } catch (_) {
+      final Directory temp = await Directory.systemTemp.createTemp('tickets_db');
+      final File file = File(p.join(temp.path, 'tickets.db'));
+      return NativeDatabase(file);
+    }
+  });
+}

--- a/lib/data/local/database/connection/connection_factory_stub.dart
+++ b/lib/data/local/database/connection/connection_factory_stub.dart
@@ -1,0 +1,4 @@
+import 'package:drift/drift.dart';
+
+QueryExecutor createExecutor() =>
+    throw UnsupportedError('No hay ejecutor de base de datos disponible.');

--- a/lib/data/local/database/connection/connection_factory_web.dart
+++ b/lib/data/local/database/connection/connection_factory_web.dart
@@ -1,0 +1,6 @@
+import 'package:drift/drift.dart';
+import 'package:drift/web.dart';
+
+QueryExecutor createExecutor() {
+  return WebDatabase('tickets_db');
+}

--- a/lib/data/repositories/ticket_repository_impl.dart
+++ b/lib/data/repositories/ticket_repository_impl.dart
@@ -6,7 +6,7 @@ import 'package:drift/drift.dart' show Value;
 import 'package:uuid/uuid.dart';
 
 import 'package:sistema_tickets_edis/core/errors/failure.dart';
-import 'package:sistema_tickets_edis/core/notifications/local_notification_service.dart';
+import 'package:sistema_tickets_edis/core/notifications/notification_service.dart';
 import 'package:sistema_tickets_edis/core/pdf/alta_document_service.dart';
 import 'package:sistema_tickets_edis/data/local/database/app_database.dart';
 import 'package:sistema_tickets_edis/domain/entities/alta_document_result.dart';
@@ -24,7 +24,7 @@ class TicketRepositoryImpl implements TicketRepository {
   TicketRepositoryImpl({
     required AppDatabase database,
     required TicketWorkflowService workflowService,
-    required LocalNotificationService notificationService,
+    required NotificationService notificationService,
     required AltaDocumentService altaDocumentService,
   }) : _database = database,
        _workflowService = workflowService,
@@ -34,7 +34,7 @@ class TicketRepositoryImpl implements TicketRepository {
 
   final AppDatabase _database;
   final TicketWorkflowService _workflowService;
-  final LocalNotificationService _notificationService;
+  final NotificationService _notificationService;
   final AltaDocumentService _altaDocumentService;
   final TicketDao _dao;
   final Uuid _uuid = const Uuid();
@@ -234,8 +234,8 @@ class TicketRepositoryImpl implements TicketRepository {
         .generateRmFgDocuments(ticket);
     await _dao.insertDmfExport(
       ticketId: ticketId,
-      pdfPath: result.pdfPath,
-      csvPath: result.csvPath,
+      pdfPath: result.pdf.reference,
+      csvPath: result.csv.reference,
     );
     await _dao.insertEvent(
       TicketEventsCompanion.insert(
@@ -245,8 +245,8 @@ class TicketRepositoryImpl implements TicketRepository {
         message: 'Documentos RM/FG generados',
         metadataJson: Value<String>(
           jsonEncode(<String, dynamic>{
-            'pdfPath': result.pdfPath,
-            'csvPath': result.csvPath,
+            'pdfReference': result.pdf.reference,
+            'csvReference': result.csv.reference,
           }),
         ),
       ),

--- a/lib/domain/entities/alta_document_result.dart
+++ b/lib/domain/entities/alta_document_result.dart
@@ -1,15 +1,30 @@
 import 'package:equatable/equatable.dart';
 
+class AltaDocumentArtifact extends Equatable {
+  const AltaDocumentArtifact({
+    required this.reference,
+    required this.fileName,
+    required this.mimeType,
+  });
+
+  final String reference;
+  final String fileName;
+  final String mimeType;
+
+  @override
+  List<Object?> get props => <Object?>[reference, fileName, mimeType];
+}
+
 /// Result for RM/FG publication artifacts.
 class AltaDocumentResult extends Equatable {
   const AltaDocumentResult({
-    required this.pdfPath,
-    required this.csvPath,
+    required this.pdf,
+    required this.csv,
   });
 
-  final String pdfPath;
-  final String csvPath;
+  final AltaDocumentArtifact pdf;
+  final AltaDocumentArtifact csv;
 
   @override
-  List<Object?> get props => <Object?>[pdfPath, csvPath];
+  List<Object?> get props => <Object?>[pdf, csv];
 }

--- a/lib/features/ticket_detail/presentation/views/ticket_detail_page.dart
+++ b/lib/features/ticket_detail/presentation/views/ticket_detail_page.dart
@@ -129,7 +129,7 @@ class _TicketDetailPageState extends ConsumerState<TicketDetailPage> {
         return;
       }
       _showBanner(
-        'Documentos generados: PDF ${result.pdfPath.split('/').last}',
+        'Documentos generados: PDF ${result.pdf.fileName}',
         isError: false,
       );
     } catch (error) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -199,7 +199,8 @@ class _AuthGuardState extends State<AuthGuard> {
                     padding: EdgeInsets.all(16),
                     child: Text(
                       'TODO Web: integra MSAL (msal-browser) o implementa un flujo PKCE manual. '
-                      'flutter_appauth no soporta Web.',
+                      'flutter_appauth no soporta Web. También puedes compilar con '
+                      '--dart-define=WEB_PREVIEW=true para navegar en modo demo sin conexión.',
                       textAlign: TextAlign.center,
                     ),
                   ),
@@ -223,8 +224,7 @@ class _AuthGuardState extends State<AuthGuard> {
               ),
               const SizedBox(height: 12),
               const Text(
-                'Recuerda conceder permisos “Admin consent” al scope '.
-                'https://<ORG>.crm.dynamics.com/.default.',
+                "Recuerda conceder permisos “Admin consent” al scope https://<ORG>.crm.dynamics.com/.default.",
                 textAlign: TextAlign.center,
               ),
             ],

--- a/lib/pages/example_page.dart
+++ b/lib/pages/example_page.dart
@@ -290,6 +290,8 @@ class _ExamplePageState extends State<ExamplePage> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
 
+    final bool isPreview = widget.dataverseApi.isPreview;
+
     final Widget listContent = _isLoadingTickets && _tickets.isEmpty
         ? const Center(child: CircularProgressIndicator())
         : RefreshIndicator(
@@ -298,6 +300,22 @@ class _ExamplePageState extends State<ExamplePage> {
               padding: const EdgeInsets.all(16),
               physics: const AlwaysScrollableScrollPhysics(),
               children: <Widget>[
+                if (isPreview)
+                  Card(
+                    color: theme.colorScheme.surfaceVariant,
+                    child: ListTile(
+                      leading: Icon(
+                        Icons.visibility_outlined,
+                        color: theme.colorScheme.primary,
+                      ),
+                      title: const Text('Modo demo sin conexión'),
+                      subtitle: const Text(
+                        'Los tickets se almacenan solo en memoria y no se '
+                        'envían a Dataverse. Compila sin WEB_PREVIEW para '
+                        'usar la integración real.',
+                      ),
+                    ),
+                  ),
                 Card(
                   child: Padding(
                     padding: const EdgeInsets.all(16),

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,36 +1,74 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import '../config/auth_config.dart';
+import '../config/preview_config.dart';
+import 'token_store/token_store.dart';
+import 'web_auth/web_auth_client.dart';
 
 class AuthService {
   AuthService({
     FlutterAppAuth? appAuth,
-    FlutterSecureStorage? secureStorage,
+    TokenStore? tokenStore,
+    WebAuthClient? webAuthClient,
     DateTime Function()? now,
-  })  : _appAuth = appAuth ?? const FlutterAppAuth(),
-        _secureStorage = secureStorage ?? const FlutterSecureStorage(),
+    bool? previewMode,
+  })  : _previewMode = previewMode ?? kUsePreviewBackend,
+        _appAuth = kIsWeb ? null : (appAuth ?? const FlutterAppAuth()),
+        _tokenStore = tokenStore ?? createTokenStore(),
+        _webAuthClient =
+            kIsWeb && !(previewMode ?? kUsePreviewBackend)
+                ? (webAuthClient ?? createWebAuthClient())
+                : null,
         _now = now ?? DateTime.now;
 
-  final FlutterAppAuth _appAuth;
-  final FlutterSecureStorage _secureStorage;
+  final FlutterAppAuth? _appAuth;
+  final TokenStore _tokenStore;
+  final WebAuthClient? _webAuthClient;
   final DateTime Function() _now;
+  final bool _previewMode;
+
+  bool _previewSessionSeeded = false;
 
   static const String _accessTokenKey = 'auth_access_token';
   static const String _refreshTokenKey = 'auth_refresh_token';
   static const String _expiryKey = 'auth_access_token_expiry';
+  static const String _accountIdKey = 'auth_account_id';
+
+  bool get isPreview => _previewMode;
 
   Future<void> login() async {
-    if (kIsWeb) {
-      throw AuthException(
-        'TODO: usa MSAL (msal-browser) o implementa un flujo PKCE manual para Web.',
-      );
+    if (_previewMode) {
+      await _ensurePreviewSession();
+      return;
     }
 
+    if (kIsWeb) {
+      final WebAuthClient client = _requireWebClient();
+      try {
+        final WebAuthResult result =
+            await client.login(scopes: AuthConfig.scopes);
+        await _persistTokens(
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+          expiry: result.expiresOn ??
+              _now().toUtc().add(const Duration(hours: 1)),
+          accountId: result.accountId,
+        );
+      } catch (error) {
+        await logout();
+        throw AuthException(
+          'Error durante el inicio de sesión web: $error',
+          error,
+        );
+      }
+      return;
+    }
+
+    final FlutterAppAuth appAuth = _requireAppAuth();
     try {
       final AuthorizationTokenResponse? response =
-          await _appAuth.authorizeAndExchangeCode(
+          await appAuth.authorizeAndExchangeCode(
         AuthorizationTokenRequest(
           AuthConfig.clientId,
           AuthConfig.redirectUriForPlatform(),
@@ -64,6 +102,10 @@ class AuthService {
   }
 
   Future<void> refreshIfNeeded() async {
+    if (_previewMode) {
+      return;
+    }
+
     final DateTime? expiry = await _readExpiry();
     if (expiry == null) {
       return;
@@ -74,21 +116,46 @@ class AuthService {
       return;
     }
 
-    await _refreshToken();
+    if (kIsWeb) {
+      await _refreshWebToken();
+    } else {
+      await _refreshNativeToken();
+    }
   }
 
   Future<void> logout() async {
-    await Future.wait(<Future<void>>[
-      _secureStorage.delete(key: _accessTokenKey),
-      _secureStorage.delete(key: _refreshTokenKey),
-      _secureStorage.delete(key: _expiryKey),
-    ]);
+    if (_previewMode) {
+      _previewSessionSeeded = false;
+    }
+
+    if (kIsWeb) {
+      final String? accountId = await _tokenStore.read(_accountIdKey);
+      try {
+        await _webAuthClient?.logout(accountId: accountId);
+      } catch (_) {
+        // Ignorar errores al cerrar sesión del lado MSAL.
+      }
+    }
+
+    await _tokenStore.deleteAll(
+      <String>[_accessTokenKey, _refreshTokenKey, _expiryKey, _accountIdKey],
+    );
   }
 
   Future<String> getAccessToken() async {
+    if (_previewMode) {
+      await _ensurePreviewSession();
+      final String? stored = await _tokenStore.read(_accessTokenKey);
+      return stored ?? _previewAccessToken;
+    }
+
     await refreshIfNeeded();
-    final String? accessToken =
-        await _secureStorage.read(key: _accessTokenKey);
+    String? accessToken = await _tokenStore.read(_accessTokenKey);
+
+    if ((accessToken == null || accessToken.isEmpty) && kIsWeb) {
+      await _refreshWebToken();
+      accessToken = await _tokenStore.read(_accessTokenKey);
+    }
 
     if (accessToken == null || accessToken.isEmpty) {
       throw const AuthException('No hay una sesión válida. Ejecuta login().');
@@ -97,9 +164,37 @@ class AuthService {
   }
 
   Future<bool> hasValidSession() async {
-    final String? accessToken =
-        await _secureStorage.read(key: _accessTokenKey);
+    if (_previewMode) {
+      await _ensurePreviewSession();
+      return true;
+    }
+
+    final String? accessToken = await _tokenStore.read(_accessTokenKey);
     final DateTime? expiry = await _readExpiry();
+
+    if (kIsWeb) {
+      final String? accountId = await _tokenStore.read(_accountIdKey);
+      if (accountId == null || accountId.isEmpty) {
+        return false;
+      }
+
+      if (accessToken == null || accessToken.isEmpty || expiry == null) {
+        try {
+          await _refreshWebToken();
+        } on AuthException {
+          return false;
+        }
+      } else {
+        try {
+          await refreshIfNeeded();
+        } on AuthException {
+          return false;
+        }
+      }
+
+      final String? refreshedToken = await _tokenStore.read(_accessTokenKey);
+      return refreshedToken != null && refreshedToken.isNotEmpty;
+    }
 
     if (accessToken == null || accessToken.isEmpty || expiry == null) {
       return false;
@@ -107,7 +202,7 @@ class AuthService {
 
     if (expiry.isBefore(_now().toUtc())) {
       try {
-        await _refreshToken();
+        await _refreshNativeToken();
       } on AuthException {
         return false;
       }
@@ -119,20 +214,13 @@ class AuthService {
       }
     }
 
-    final String? refreshedToken =
-        await _secureStorage.read(key: _accessTokenKey);
+    final String? refreshedToken = await _tokenStore.read(_accessTokenKey);
     return refreshedToken != null && refreshedToken.isNotEmpty;
   }
 
-  Future<void> _refreshToken() async {
-    if (kIsWeb) {
-      throw AuthException(
-        'TODO: usa MSAL (msal-browser) o implementa un flujo PKCE manual para Web.',
-      );
-    }
-
-    final String? storedRefreshToken =
-        await _secureStorage.read(key: _refreshTokenKey);
+  Future<void> _refreshNativeToken() async {
+    final FlutterAppAuth appAuth = _requireAppAuth();
+    final String? storedRefreshToken = await _tokenStore.read(_refreshTokenKey);
     if (storedRefreshToken == null || storedRefreshToken.isEmpty) {
       throw const AuthException(
         'No hay refresh_token disponible. Inicia sesión nuevamente.',
@@ -140,7 +228,7 @@ class AuthService {
     }
 
     try {
-      final TokenResponse? response = await _appAuth.token(
+      final TokenResponse? response = await appAuth.token(
         TokenRequest(
           AuthConfig.clientId,
           AuthConfig.redirectUriForPlatform(),
@@ -173,26 +261,61 @@ class AuthService {
     }
   }
 
+  Future<void> _refreshWebToken() async {
+    if (_previewMode) {
+      throw const AuthException(
+        'La autenticación web no está disponible en modo preview.',
+      );
+    }
+
+    final WebAuthClient client = _requireWebClient();
+    final String? accountId = await _tokenStore.read(_accountIdKey);
+    if (accountId == null || accountId.isEmpty) {
+      throw const AuthException(
+        'No hay una cuenta web disponible. Inicia sesión nuevamente.',
+      );
+    }
+
+    try {
+      final WebAuthResult result = await client.acquireTokenSilent(
+        scopes: AuthConfig.scopes,
+        accountId: accountId,
+      );
+      await _persistTokens(
+        accessToken: result.accessToken,
+        refreshToken: result.refreshToken,
+        expiry: result.expiresOn ??
+            _now().toUtc().add(const Duration(hours: 1)),
+        accountId: result.accountId ?? accountId,
+      );
+    } catch (error) {
+      await logout();
+      throw AuthException('Error al refrescar el token web: $error', error);
+    }
+  }
+
   Future<void> _persistTokens({
     required String accessToken,
     String? refreshToken,
     required DateTime expiry,
+    String? accountId,
   }) async {
-    await _secureStorage.write(key: _accessTokenKey, value: accessToken);
+    await _tokenStore.write(_accessTokenKey, accessToken);
     if (refreshToken != null && refreshToken.isNotEmpty) {
-      await _secureStorage.write(
-        key: _refreshTokenKey,
-        value: refreshToken,
-      );
+      await _tokenStore.write(_refreshTokenKey, refreshToken);
+    } else {
+      await _tokenStore.delete(_refreshTokenKey);
     }
-    await _secureStorage.write(
-      key: _expiryKey,
-      value: expiry.toUtc().toIso8601String(),
-    );
+    await _tokenStore.write(_expiryKey, expiry.toUtc().toIso8601String());
+    if (accountId != null && accountId.isNotEmpty) {
+      await _tokenStore.write(_accountIdKey, accountId);
+    } else {
+      await _tokenStore.delete(_accountIdKey);
+    }
   }
 
   Future<DateTime?> _readExpiry() async {
-    final String? storedExpiry = await _secureStorage.read(key: _expiryKey);
+    final String? storedExpiry = await _tokenStore.read(_expiryKey);
     if (storedExpiry == null) {
       return null;
     }
@@ -201,6 +324,48 @@ class AuthService {
     } catch (_) {
       return null;
     }
+  }
+
+  Future<void> _ensurePreviewSession() async {
+    if (!_previewMode) {
+      return;
+    }
+    if (_previewSessionSeeded) {
+      return;
+    }
+
+    final DateTime expiry = _now().toUtc().add(const Duration(days: 30));
+    await _persistTokens(
+      accessToken: _previewAccessToken,
+      refreshToken: _previewRefreshToken,
+      expiry: expiry,
+      accountId: _previewAccountId,
+    );
+    _previewSessionSeeded = true;
+  }
+
+  static const String _previewAccessToken = 'preview-access-token';
+  static const String _previewRefreshToken = 'preview-refresh-token';
+  static const String _previewAccountId = 'preview-account';
+
+  FlutterAppAuth _requireAppAuth() {
+    final FlutterAppAuth? appAuth = _appAuth;
+    if (appAuth == null) {
+      throw const AuthException(
+        'La autenticación nativa no está disponible en esta plataforma.',
+      );
+    }
+    return appAuth;
+  }
+
+  WebAuthClient _requireWebClient() {
+    final WebAuthClient? client = _webAuthClient;
+    if (client == null) {
+      throw const AuthException(
+        'La autenticación web no está configurada para esta plataforma.',
+      );
+    }
+    return client;
   }
 }
 

--- a/lib/services/dataverse_api.dart
+++ b/lib/services/dataverse_api.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../config/auth_config.dart';
+import '../config/preview_config.dart';
 import '../models/ticket.dart';
 import 'auth_service.dart';
 
@@ -10,11 +11,28 @@ class DataverseApi {
   DataverseApi({
     AuthService? authService,
     http.Client? httpClient,
+    List<Ticket>? previewSeed,
+    bool? previewMode,
   })  : _authService = authService ?? AuthService(),
-        _httpClient = httpClient ?? http.Client();
+        _httpClient = httpClient ?? http.Client(),
+        _previewMode =
+            previewMode ?? (authService?.isPreview ?? false) || kUsePreviewBackend,
+        _previewTickets = <Ticket>[],
+        _previewSequence = 0 {
+    if (_previewMode) {
+      final Iterable<Ticket> seed = previewSeed ?? _defaultPreviewTickets;
+      _previewTickets.addAll(List<Ticket>.of(seed));
+      _previewSequence = _previewTickets.length;
+    }
+  }
 
   final AuthService _authService;
   final http.Client _httpClient;
+  final bool _previewMode;
+  final List<Ticket> _previewTickets;
+  int _previewSequence;
+
+  bool get isPreview => _previewMode;
 
   static Uri get _collectionUri =>
       Uri.parse('${AuthConfig.organizationHost}/api/data/v9.2/new_tickets');
@@ -24,6 +42,10 @@ class DataverseApi {
     String? filter,
     String? orderBy,
   }) async {
+    if (_previewMode) {
+      return _previewTickets.take(top).toList();
+    }
+
     final List<Ticket> tickets = <Ticket>[];
     Uri? requestUri = _buildListUri(top: top, filter: filter, orderBy: orderBy);
 
@@ -54,6 +76,17 @@ class DataverseApi {
     required String priority,
     required String status,
   }) async {
+    if (_previewMode) {
+      final Ticket ticket = Ticket(
+        id: _generatePreviewId(),
+        title: title,
+        priority: priority,
+        status: status,
+      );
+      _previewTickets.insert(0, ticket);
+      return ticket;
+    }
+
     final String token = await _authService.getAccessToken();
     final http.Response response = await _httpClient.post(
       _collectionUri,
@@ -89,6 +122,25 @@ class DataverseApi {
     String? priority,
     String? status,
   }) async {
+    if (_previewMode) {
+      final int index =
+          _previewTickets.indexWhere((Ticket ticket) => ticket.id == id);
+      if (index == -1) {
+        throw DataverseApiException(
+          'No se encontró el ticket $id en el modo preview.',
+        );
+      }
+
+      final Ticket current = _previewTickets[index];
+      final Ticket updated = current.copyWith(
+        title: title?.isNotEmpty == true ? title : null,
+        priority: priority?.isNotEmpty == true ? priority : null,
+        status: status?.isNotEmpty == true ? status : null,
+      );
+      _previewTickets[index] = updated;
+      return;
+    }
+
     final Map<String, dynamic> updates = <String, dynamic>{};
     if (title != null) {
       updates['new_title'] = title;
@@ -116,6 +168,18 @@ class DataverseApi {
   }
 
   Future<void> deleteTicket(String id) async {
+    if (_previewMode) {
+      final int previousLength = _previewTickets.length;
+      _previewTickets.removeWhere((Ticket ticket) => ticket.id == id);
+      final bool wasRemoved = _previewTickets.length != previousLength;
+      if (!wasRemoved) {
+        throw DataverseApiException(
+          'No se pudo eliminar el ticket $id en modo preview.',
+        );
+      }
+      return;
+    }
+
     final String token = await _authService.getAccessToken();
     final Uri resourceUri = _ticketUri(id);
     final http.Response response = await _httpClient.delete(
@@ -129,6 +193,27 @@ class DataverseApi {
   void dispose() {
     _httpClient.close();
   }
+
+  static const List<Ticket> _defaultPreviewTickets = <Ticket>[
+    Ticket(
+      id: 'preview-1',
+      title: 'Demo: seguimiento de incidente',
+      priority: 'Alta',
+      status: 'Abierto',
+    ),
+    Ticket(
+      id: 'preview-2',
+      title: 'Demo: revisión de equipo',
+      priority: 'Media',
+      status: 'En progreso',
+    ),
+    Ticket(
+      id: 'preview-3',
+      title: 'Demo: seguimiento preventivo',
+      priority: 'Baja',
+      status: 'Cerrado',
+    ),
+  ];
 
   Uri _buildListUri({
     required int top,
@@ -224,6 +309,13 @@ class DataverseApi {
         RegExp(r'([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})')
             .firstMatch(entityId);
     return match?.group(1);
+  }
+
+  String _generatePreviewId() {
+    _previewSequence++;
+    final String timestamp = DateTime.now().millisecondsSinceEpoch.toString();
+    final String sequence = _previewSequence.toString().padLeft(3, '0');
+    return 'preview-$timestamp-$sequence';
   }
 }
 

--- a/lib/services/token_store/token_store.dart
+++ b/lib/services/token_store/token_store.dart
@@ -1,0 +1,20 @@
+import 'token_store_stub.dart'
+    if (dart.library.html) 'token_store_web.dart'
+    if (dart.library.io) 'token_store_secure.dart';
+
+/// Persiste tokens de autenticación en el medio apropiado para la plataforma.
+abstract class TokenStore {
+  Future<void> write(String key, String value);
+
+  Future<String?> read(String key);
+
+  Future<void> delete(String key);
+
+  Future<void> deleteAll(Iterable<String> keys) async {
+    for (final String key in keys) {
+      await delete(key);
+    }
+  }
+}
+
+TokenStore createTokenStore() => createTokenStoreImpl();

--- a/lib/services/token_store/token_store_secure.dart
+++ b/lib/services/token_store/token_store_secure.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+import 'token_store.dart';
+
+class SecureTokenStore implements TokenStore {
+  SecureTokenStore([FlutterSecureStorage? storage])
+      : _storage = storage ?? const FlutterSecureStorage();
+
+  final FlutterSecureStorage _storage;
+
+  @override
+  Future<void> write(String key, String value) {
+    return _storage.write(key: key, value: value);
+  }
+
+  @override
+  Future<String?> read(String key) {
+    return _storage.read(key: key);
+  }
+
+  @override
+  Future<void> delete(String key) {
+    return _storage.delete(key: key);
+  }
+
+  @override
+  Future<void> deleteAll(Iterable<String> keys) async {
+    for (final String key in keys) {
+      await _storage.delete(key: key);
+    }
+  }
+}
+
+TokenStore createTokenStoreImpl() => SecureTokenStore();

--- a/lib/services/token_store/token_store_stub.dart
+++ b/lib/services/token_store/token_store_stub.dart
@@ -1,0 +1,4 @@
+import 'token_store.dart';
+
+TokenStore createTokenStoreImpl() => throw UnsupportedError(
+    'TokenStore no está disponible para esta plataforma.');

--- a/lib/services/token_store/token_store_web.dart
+++ b/lib/services/token_store/token_store_web.dart
@@ -1,0 +1,50 @@
+import 'dart:html' as html;
+
+import 'token_store.dart';
+
+class WebTokenStore implements TokenStore {
+  WebTokenStore([html.Storage? storage]) : _storage = storage ?? _resolveStorage();
+
+  final html.Storage? _storage;
+
+  static html.Storage? _resolveStorage() {
+    try {
+      return html.window.localStorage;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  html.Storage _ensureStorage() {
+    final html.Storage? storage = _storage;
+    if (storage == null) {
+      throw UnsupportedError('localStorage no está disponible en este navegador.');
+    }
+    return storage;
+  }
+
+  @override
+  Future<void> write(String key, String value) async {
+    _ensureStorage()[key] = value;
+  }
+
+  @override
+  Future<String?> read(String key) async {
+    return _ensureStorage()[key];
+  }
+
+  @override
+  Future<void> delete(String key) async {
+    _ensureStorage().remove(key);
+  }
+
+  @override
+  Future<void> deleteAll(Iterable<String> keys) async {
+    final html.Storage storage = _ensureStorage();
+    for (final String key in keys) {
+      storage.remove(key);
+    }
+  }
+}
+
+TokenStore createTokenStoreImpl() => WebTokenStore();

--- a/lib/services/web_auth/web_auth_client.dart
+++ b/lib/services/web_auth/web_auth_client.dart
@@ -1,0 +1,29 @@
+import 'web_auth_client_stub.dart'
+    if (dart.library.html) 'web_auth_client_web.dart';
+
+class WebAuthResult {
+  const WebAuthResult({
+    required this.accessToken,
+    this.refreshToken,
+    this.expiresOn,
+    this.accountId,
+  });
+
+  final String accessToken;
+  final String? refreshToken;
+  final DateTime? expiresOn;
+  final String? accountId;
+}
+
+abstract class WebAuthClient {
+  Future<WebAuthResult> login({required List<String> scopes});
+
+  Future<WebAuthResult> acquireTokenSilent({
+    required List<String> scopes,
+    String? accountId,
+  });
+
+  Future<void> logout({String? accountId});
+}
+
+WebAuthClient createWebAuthClient() => createWebAuthClientImpl();

--- a/lib/services/web_auth/web_auth_client_stub.dart
+++ b/lib/services/web_auth/web_auth_client_stub.dart
@@ -1,0 +1,21 @@
+import 'web_auth_client.dart';
+
+WebAuthClient createWebAuthClientImpl() => _UnsupportedWebAuthClient();
+
+class _UnsupportedWebAuthClient implements WebAuthClient {
+  @override
+  Future<WebAuthResult> acquireTokenSilent({
+    required List<String> scopes,
+    String? accountId,
+  }) {
+    throw UnsupportedError('WebAuthClient no está disponible en esta plataforma.');
+  }
+
+  @override
+  Future<WebAuthResult> login({required List<String> scopes}) {
+    throw UnsupportedError('WebAuthClient no está disponible en esta plataforma.');
+  }
+
+  @override
+  Future<void> logout({String? accountId}) async {}
+}

--- a/lib/services/web_auth/web_auth_client_web.dart
+++ b/lib/services/web_auth/web_auth_client_web.dart
@@ -1,0 +1,86 @@
+import 'package:msal_js/msal_js.dart' as msal;
+
+import '../../config/auth_config.dart';
+import 'web_auth_client.dart';
+
+class MsalWebAuthClient implements WebAuthClient {
+  MsalWebAuthClient([msal.PublicClientApplication? application])
+      : _application = application ?? _buildApplication();
+
+  final msal.PublicClientApplication _application;
+
+  static msal.PublicClientApplication _buildApplication() {
+    final msal.Configuration configuration = msal.Configuration()
+      ..auth = (msal.BrowserAuthOptions()
+        ..clientId = AuthConfig.clientId
+        ..authority = AuthConfig.authority
+        ..redirectUri = AuthConfig.redirectUriWeb)
+      ..cache = (msal.CacheOptions()
+        ..cacheLocation = msal.BrowserCacheLocation.localStorage
+        ..storeAuthStateInCookie = false);
+    return msal.PublicClientApplication(configuration);
+  }
+
+  @override
+  Future<WebAuthResult> login({required List<String> scopes}) async {
+    final msal.PopupRequest request = msal.PopupRequest()..scopes = scopes;
+    final msal.AuthenticationResult result =
+        await _application.loginPopup(request);
+    return _mapResult(result);
+  }
+
+  @override
+  Future<WebAuthResult> acquireTokenSilent({
+    required List<String> scopes,
+    String? accountId,
+  }) async {
+    final msal.AccountInfo? account = _resolveAccount(accountId);
+    final msal.SilentRequest request = msal.SilentRequest()
+      ..scopes = scopes
+      ..account = account;
+    final msal.AuthenticationResult result =
+        await _application.acquireTokenSilent(request);
+    return _mapResult(result);
+  }
+
+  @override
+  Future<void> logout({String? accountId}) async {
+    final msal.AccountInfo? account = _resolveAccount(accountId);
+    final msal.EndSessionPopupRequest request =
+        msal.EndSessionPopupRequest()..account = account;
+    await _application.logoutPopup(request);
+  }
+
+  WebAuthResult _mapResult(msal.AuthenticationResult result) {
+    final String? accessToken = result.accessToken;
+    if (accessToken == null || accessToken.isEmpty) {
+      throw StateError('MSAL no devolvió un accessToken válido.');
+    }
+    final DateTime? expiresOn = result.expiresOn;
+    final String? accountId = result.account?.homeAccountId;
+    return WebAuthResult(
+      accessToken: accessToken,
+      refreshToken: null,
+      expiresOn: expiresOn?.toUtc(),
+      accountId: accountId,
+    );
+  }
+
+  msal.AccountInfo? _resolveAccount(String? accountId) {
+    final List<msal.AccountInfo> accounts = _application.getAllAccounts();
+    if (accounts.isEmpty) {
+      return null;
+    }
+    if (accountId == null || accountId.isEmpty) {
+      return accounts.first;
+    }
+    for (final msal.AccountInfo account in accounts) {
+      if (account.homeAccountId == accountId) {
+        return account;
+      }
+    }
+    return accounts.first;
+  }
+}
+
+WebAuthClient createWebAuthClientImpl() => MsalWebAuthClient();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   flutter_appauth: ^6.0.0
   http: ^1.2.0
   flutter_secure_storage: ^9.0.0
+  msal_js: ^2.4.0
 
 dev_dependencies:
   flutter_test:

--- a/web/index.html
+++ b/web/index.html
@@ -31,6 +31,7 @@
 
   <title>sistema_tickets_edis</title>
   <link rel="manifest" href="manifest.json">
+  <script src="https://alcdn.msauth.net/browser/2.38.0/js/msal-browser.min.js" crossorigin="anonymous"></script>
 </head>
 <body>
   <script src="flutter_bootstrap.js" async></script>


### PR DESCRIPTION
## Summary
- configure the MSAL web client using property setters and request builders supported by msal_js
- implement `deleteAll` for secure and web token stores to satisfy the shared interface
- collapse the login scope guidance string so it parses correctly during web builds
- add a WEB_PREVIEW toggle that seeds an in-memory AuthService/DataverseApi session, skipping Azure login and serving demo tickets
- highlight the demo mode in the sample UI and README so builds can choose between connected and offline flows
- fix preview ticket deletion accounting and align MSAL logout with the EndSessionPopup request expected by msal_js

## Testing
- `dart format .` *(fails: dart command not available in container)*
- `flutter test` *(fails: flutter command not available in container)*
- `flutter build apk` *(fails: flutter command not available in container)*
- `flutter build ipa` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d37f74e374832082e083bab4769d36